### PR TITLE
Update June post-Google positioning

### DIFF
--- a/app/content/index.mdx
+++ b/app/content/index.mdx
@@ -12,7 +12,7 @@ import ConwayGame from '@/components/DynamicConway'
 
 <ConwayGame />
 
-Daniel is an American technologist and founder of [Three Rules Company](https://threerulescompany.com/), an advisory and technology studio working across data, AI, finance, and operating systems.
+Daniel is an American technologist and founder of [Three Rules Company](https://threerulescompany.com/), an advisory and technology studio working across data systems, private agents, finance, and operating cadence.
 
 Beginning June 16, 2026, Daniel is operating independently after eight years at [Google](https://about.google/) APAC, most recently as Data Lead for an international growth team. Current advisory work spans agriculture, gaming, and e-commerce.
 
@@ -34,7 +34,7 @@ Explore curated resources on topics I care about in [Going Deep](/going-deep).
 
 ## Recent Projects
 
-- [Three Rules Company](https://threerulescompany.com/) - Advisory and product work across data, AI, finance, and operating cadence.
+- [Three Rules Company](https://threerulescompany.com/) - Advisory and product work across data systems, private agents, finance, and operating cadence.
 - [Underlines News](https://www.underlines.news/) - A media experiment for concise, multi-perspective analysis of major events.
 - [LP9](https://lp9.threerulescompany.com/) - A life planning application for goals, habits, and long-term direction.
 - [ダニエルの言葉発見](https://www.youtube.com/@%E3%83%80%E3%83%8B%E3%82%A8%E3%83%AB%E3%81%AE%E8%A8%80%E8%91%89%E7%99%BA%E8%A6%8B) - A YouTube channel where an American explores fascinating nuances of Japanese and Chinese languages, making complex linguistic concepts accessible through humor and snapshots of daily life.

--- a/app/content/index.mdx
+++ b/app/content/index.mdx
@@ -12,7 +12,9 @@ import ConwayGame from '@/components/DynamicConway'
 
 <ConwayGame />
 
-Daniel is an American technologist, currently Data Lead at [Google](https://about.google/) APAC, where he has worked for eight years.
+Daniel is an American technologist and founder of [Three Rules Company](https://threerulescompany.com/), an advisory and technology studio working across data, AI, finance, and operating systems.
+
+Beginning June 16, 2026, Daniel is operating independently after eight years at [Google](https://about.google/) APAC, most recently as Data Lead for an international growth team. Current advisory work spans agriculture, gaming, and e-commerce.
 
 Previously, he worked for 10 years in mainland China, where he led business strategy and entrepreneurial software teams.
 
@@ -32,8 +34,9 @@ Explore curated resources on topics I care about in [Going Deep](/going-deep).
 
 ## Recent Projects
 
-- [Underlines News](https://www.underlines.news/) - A news analysis and media experiment focused on clear, concise briefings that cut through noise to provide essential context and implications of major events.
-- [LP9](https://lp9.threerulescompany.com/) - A comprehensive life planning web application that helps users systematically organize and track their personal and professional goals, habits, and long-term aspirations.
+- [Three Rules Company](https://threerulescompany.com/) - Advisory and product work across data, AI, finance, and operating cadence.
+- [Underlines News](https://www.underlines.news/) - A media experiment for concise, multi-perspective analysis of major events.
+- [LP9](https://lp9.threerulescompany.com/) - A life planning application for goals, habits, and long-term direction.
 - [ダニエルの言葉発見](https://www.youtube.com/@%E3%83%80%E3%83%8B%E3%82%A8%E3%83%AB%E3%81%AE%E8%A8%80%E8%91%89%E7%99%BA%E8%A6%8B) - A YouTube channel where an American explores fascinating nuances of Japanese and Chinese languages, making complex linguistic concepts accessible through humor and snapshots of daily life.
 - [Building on Fire](https://www.youtube.com/@building-on-fire) - A YouTube channel focused on agentic coding and practical insights gained from working with AI coding agents, emphasizing autonomous problem-solving and effective collaboration with AI tools.
 - [LLM Nexus](https://github.com/dtedesco1/llm_nexus), an open-source Python package that provides a single interface for interacting with multiple Language Model providers.

--- a/app/content/now.mdx
+++ b/app/content/now.mdx
@@ -1,18 +1,21 @@
 # Now
 
-Last updated: May 2026
+Last updated: June 2026
 
 ## Where am I
 
 Often between Beijing and Kunming, China.
 
-## What is my day job
+## What is my work
 
-I work for [Google](https://about.google/), currently as Data Lead for an international growth team across APAC. I've been at Google for eight years. For my first five years at the company, I advised APAC game companies on global expansion.
+Beginning June 16, 2026, I am operating independently after eight years at [Google](https://about.google/) APAC, most recently as Data Lead for an international growth team.
+
+I am taking selective advisory and product work through [Three Rules Company](https://threerulescompany.com/). Current client sectors include agriculture, gaming, and e-commerce. I am already booked through July, so new advisory starts are scheduling from August.
 
 ## What else am I spending time on
 
-- Turning my life planning tool into [LP9](https://www.lp9.threerulescompany.com), a web app for organizing goals, habits, and long-term direction.
+- Building Three Rules Company around focused advisory, private AI operators, and product experiments.
+- Turning my life planning tool into [LP9](https://lp9.threerulescompany.com), a web app for organizing goals, habits, and long-term direction.
 - Sending news analyses on [Underlines News](https://www.underlines.news/).
 - Planning a July Japan trip with Flora, including Tokyo and Fuji Rock.
 - Deepening faith, studying Japanese, rebuilding music habits, reading [books](/going-deep/books), playing [games](/going-deep/games), and enjoying other [art](/going-deep/art).


### PR DESCRIPTION
## Summary
- Refresh homepage bio language for Daniel's June 16 transition.
- Update the Now page from active Google day-job language to independent TRC work.
- Mention current client sectors as agriculture, gaming, and e-commerce without naming clients.
- Tighten Underlines and LP9 descriptions so they read as active products, not a sales pitch.

## Copy stance
- Uses "operating independently" rather than contract/free-agent language.
- Keeps availability confident: booked through July, new starts scheduling from August.
- Keeps client references sector-level only.

## Verification
- npm run build
- HTTP smoke: http://localhost:3102/ returned 200 and included the TRC, June 16, and client-sector language.
- HTTP smoke: http://localhost:3102/now returned 200 and included the June 16, client-sector, and booked-through-July language.

Fixes #8