### PR TITLE
June 2026: Google → Three Rules Company (bio + Now)

### DIFF
--- a/app/content/index.mdx
+++ b/app/content/index.mdx
@@ -12,9 +12,9 @@ import ConwayGame from '@/components/DynamicConway'
 
 <ConwayGame />
 
-Daniel is an American technologist, currently Data Lead at [Google](https://about.google/) APAC, where he has worked for eight years.
+Daniel is an American technologist and the founder of [Three Rules Company](https://threerulescompany.com/), a technology studio incubating products and building AI agents. In June 2026, he began building this full-time, after eight years at [Google](https://about.google/) APAC — most recently as Data Lead for an international growth team.
 
-Previously, he worked for 10 years in mainland China, where he led business strategy and entrepreneurial software teams.
+Before Google, he spent 10 years in mainland China, leading business strategy and entrepreneurial software teams.
 
 Daniel has been a [Fulbright Scholar](https://www.fulbrightprogram.org/) and holds an MBA from [Columbia University](https://www.columbia.edu/).
 
@@ -32,6 +32,7 @@ Explore curated resources on topics I care about in [Going Deep](/going-deep).
 
 ## Recent Projects
 
+- [Three Rules Company](https://threerulescompany.com/) - A technology studio incubating products and building AI agents, with data and finance advisory.
 - [Underlines News](https://www.underlines.news/) - A news analysis and media experiment focused on clear, concise briefings that cut through noise to provide essential context and implications of major events.
 - [LP9](https://lp9.threerulescompany.com/) - A comprehensive life planning web application that helps users systematically organize and track their personal and professional goals, habits, and long-term aspirations.
 - [ダニエルの言葉発見](https://www.youtube.com/@%E3%83%80%E3%83%8B%E3%82%A8%E3%83%AB%E3%81%AE%E8%A8%80%E8%91%89%E7%99%BA%E8%A6%8B) - A YouTube channel where an American explores fascinating nuances of Japanese and Chinese languages, making complex linguistic concepts accessible through humor and snapshots of daily life.
@@ -42,4 +43,4 @@ Explore curated resources on topics I care about in [Going Deep](/going-deep).
 
 ## Social
 
-[LinkedIn](https://www.linkedin.com/in/danieltedesco/) | [Substack](https://danieltedesco.substack.com/) | [X](https://x.com/dtedesco1) | [GitHub](https://github.com/dtedesco1) | [Email](mailto:contact@dtedes.co)
+[LinkedIn](https://www.linkedin.com/in/danieltedesco/) | [Substack](https://danieltedesco.substack.com/) | [X](https://x.com/dtedesco1) | [GitHub](https://github.com/dtedesco1) | [Email](mailto:daniel.tedesco@threerulescompany.com)

--- a/app/content/index.mdx
+++ b/app/content/index.mdx
@@ -12,7 +12,7 @@ import ConwayGame from '@/components/DynamicConway'
 
 <ConwayGame />
 
-Daniel is an American technologist and the founder of [Three Rules Company](https://threerulescompany.com/), a technology studio incubating products and building AI agents. In June 2026, he began building this full-time, after eight years at [Google](https://about.google/) APAC — most recently as Data Lead for an international growth team.
+Daniel is an American technologist and the founder of [Three Rules Company](https://threerulescompany.com/), a technology studio incubating products and building AI agents. Previously, he worked for eight years at [Google](https://about.google/) as Data Lead for the international growth team.
 
 Before Google, he spent 10 years in mainland China, leading business strategy and entrepreneurial software teams.
 

--- a/app/content/now.mdx
+++ b/app/content/now.mdx
@@ -1,18 +1,21 @@
 # Now
 
-Last updated: May 2026
+Last updated: June 2026
 
 ## Where am I
 
 Often between Beijing and Kunming, China.
 
-## What is my day job
+## What is my work
 
-I work for [Google](https://about.google/), currently as Data Lead for an international growth team across APAC. I've been at Google for eight years. For my first five years at the company, I advised APAC game companies on global expansion.
+As of June 16, 2026, I've left [Google](https://about.google/) after eight years across APAC — most recently as Data Lead for an international growth team — to build [Three Rules Company](https://threerulescompany.com/) full-time.
+
+Three Rules is a technology studio. We incubate our own products (LP9 and Underlines, so far), build live AI agents for clients across agriculture, gaming, and e-commerce, and advise on the data and finance questions in between. Consulting funds the studio while the product work compounds.
+
+If you're building something where AI and data have to actually work, I'd like to hear about it: daniel.tedesco@threerulescompany.com.
 
 ## What else am I spending time on
 
-- Turning my life planning tool into [LP9](https://www.lp9.threerulescompany.com), a web app for organizing goals, habits, and long-term direction.
-- Sending news analyses on [Underlines News](https://www.underlines.news/).
+- Building and incubating products at Three Rules Company, including [LP9](https://lp9.threerulescompany.com) and [Underlines News](https://www.underlines.news/).
 - Planning a July Japan trip with Flora, including Tokyo and Fuji Rock.
 - Deepening faith, studying Japanese, rebuilding music habits, reading [books](/going-deep/books), playing [games](/going-deep/games), and enjoying other [art](/going-deep/art).

--- a/app/content/now.mdx
+++ b/app/content/now.mdx
@@ -8,7 +8,7 @@ Often between Beijing and Kunming, China.
 
 ## What is my work
 
-As of June 16, 2026, I've left [Google](https://about.google/) after eight years across APAC — most recently as Data Lead for an international growth team — to build [Three Rules Company](https://threerulescompany.com/) full-time.
+I've left [Google](https://about.google/) after eight years to build [Three Rules Company](https://threerulescompany.com/). It's exhilarating and busy.
 
 Three Rules is a technology studio. We incubate our own products (LP9 and Underlines, so far), build live AI agents for clients across agriculture, gaming, and e-commerce, and advise on the data and finance questions in between. Consulting funds the studio while the product work compounds.
 
@@ -16,6 +16,6 @@ If you're building something where AI and data have to actually work, I'd like t
 
 ## What else am I spending time on
 
-- Building and incubating products at Three Rules Company, including [LP9](https://lp9.threerulescompany.com) and [Underlines News](https://www.underlines.news/).
+- Building and incubating our baby Three Rules products, including [LP9](https://lp9.threerulescompany.com) and [Underlines News](https://www.underlines.news/).
 - Planning a July Japan trip with Flora, including Tokyo and Fuji Rock.
 - Deepening faith, studying Japanese, rebuilding music habits, reading [books](/going-deep/books), playing [games](/going-deep/games), and enjoying other [art](/going-deep/art).


### PR DESCRIPTION
Updates dtedes.co for Daniel's June 16, 2026 transition from Google to Three Rules Company full-time. Bio + Now page now describe TRC as a technology studio incubating products (LP9, Underlines), building AI agents for clients (agriculture, gaming, e-commerce, sector-level only), and doing data & finance advisory. Forward-looking, no scarcity. Contact: daniel.tedesco@threerulescompany.com.