### PR TITLE
Prepare static export for Cloudflare Pages

### DIFF
--- a/app/[...slug]/page.tsx
+++ b/app/[...slug]/page.tsx
@@ -1,7 +1,28 @@
 import { notFound } from 'next/navigation'
-import { existsSync } from 'fs'
+import { existsSync, readdirSync } from 'fs'
 import { join } from 'path'
 import { PageProps as NextPageProps } from '@/.next/types/app/[...slug]/page'
+
+function getContentSlugs(directory: string, segments: string[] = []): string[][] {
+    return readdirSync(directory, { withFileTypes: true })
+        .sort((a, b) => a.name.localeCompare(b.name))
+        .flatMap((entry) => {
+            if (entry.isDirectory()) {
+                return getContentSlugs(join(directory, entry.name), [...segments, entry.name])
+            }
+
+            if (entry.isFile() && entry.name.endsWith('.mdx')) {
+                return [[...segments, entry.name.slice(0, -4)]]
+            }
+
+            return []
+        })
+}
+
+export function generateStaticParams() {
+    return getContentSlugs(join(process.cwd(), 'app/content'))
+        .map((slug) => ({ slug }))
+}
 
 export default async function Page({ params }: NextPageProps) {
     const { slug } = await params

--- a/app/api/web-projects/route.ts
+++ b/app/api/web-projects/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from 'next/server'
 import fs from 'fs'
 import path from 'path'
 
+export const dynamic = 'force-static'
+
 export async function GET() {
     const webProjectsDir = path.join(process.cwd(), 'public', 'web-projects')
 
@@ -39,4 +41,4 @@ export async function GET() {
             projects: []
         })
     }
-} 
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,6 +2,7 @@ import createMDX from '@next/mdx'
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+    output: 'export',
     pageExtensions: ['js', 'jsx', 'mdx', 'ts', 'tsx'],
     experimental: {
         mdxRs: true // Enable Rust-based MDX compiler


### PR DESCRIPTION
## What
- enable Next.js static export to `out/`
- pre-render the dynamic MDX slug routes
- emit the web-projects API response as a static build artifact

## Why
Prepare the site for a Cloudflare Pages deployment on the Free plan while keeping the current Vercel production site untouched.

## Impact
- no environment-variable changes
- no DNS changes
- no generated `out/` files committed
- the production branch remains unchanged until this PR is reviewed and merged

## Verification
- `npm run build` completed successfully
- generated a pure static `out/` directory
- verified page, gallery, and static API output